### PR TITLE
various cleanup tasks

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -12,7 +12,4 @@ module.exports = {
     Polymer: false,
     page: false,
   },
-  plugins: [
-    "eslint-plugin-script-tags"
-  ],
 };

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = {
     'vars-on-top': 'off',
     'wrap-iife': ['error', 'inside'],
     'yoda': ['error', 'never', {exceptRange: true}],
-    'strict': ['error', 'global'],
+    'strict': ['error', 'safe'],
 
     // Variables
     'init-declarations': 'off',

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "test": "ava"
   },
   "peerDependencies": {
-    "eslint": ">=3.5.0",
-    "eslint-plugin-script-tags": "^0.1.4"
+    "eslint": ">=3.5.0"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smartcar",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Shareable eslint config for smartcar",
   "main": "index.js",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,15 @@ To run the linter on your project simply run `npm run lint` and ESLint will repo
 back errors and warnings. You can also run `npm run lint -- --fix` to use ESLint's
 automatic fix mode, this will fix most simple style and spacing errors.
 
-Alternatively use [`smartcar/browser`](browser.js) if you're in the browser:
+
+### Frontend Linting
+
+It is suggested to use [`miyagi`](https://github.com/smartcar/miyagi) for front
+end projects as it exposes utilities for linting javascript, css and html. This
+project is meant to just codify linting rules for javascript.
+
+If you wish to use the browser rules directly with eslint you can choose to
+extend [`smartcar/browser`](browser.js).
 
 ```js
 module.exports = {

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 ## Install
 
+*This package is intended for internal use and may not follow Semver guidelines*
+
 ```
 $ npm install --save-dev eslint eslint-config-smartcar
 ```

--- a/readme.md
+++ b/readme.md
@@ -13,23 +13,28 @@ $ npm install --save-dev eslint eslint-config-smartcar
 You may also be able to integrate ESLint into your text editor, a list of integrations
 is available [here](http://eslint.org/docs/user-guide/integrations).
 
-**Note:** If you intall eslint globally, you have to install eslint-config-smartcar
+**Note:** If you install eslint globally, you have to install eslint-config-smartcar
 globally as well (as per [eslint#3293](https://github.com/eslint/eslint/issues/3293)).
 It is recommended to install locally and add scripts to package.json as detailed under usage below.
 
 ## Usage
 
-Add some ESLint config to your `package.json`:
+Create a .eslintrc.js file in the root of your project containing the following:
+
+```js
+module.exports = {
+  extends: 'smartcar',
+};
+```
+
+Add a npm bin script for linting
 
 ```json
 {
-	"name": "my-awesome-project",
-	"scripts": {
-		"lint": "eslint ."
-	},
-	"eslintConfig": {
-		"extends": "smartcar"
-	}
+  "name": "my-awesome-project",
+  "scripts": {
+    "lint": "eslint ."
+  },
 }
 ```
 
@@ -39,24 +44,22 @@ automatic fix mode, this will fix most simple style and spacing errors.
 
 Alternatively use [`smartcar/browser`](browser.js) if you're in the browser:
 
-```json
-{
-	"extends": "smartcar/browser"
-}
+```js
+module.exports = {
+  extends: 'smartcar/browser',
+};
 ```
 
 ## Ignoring
 
 - Ignore at a project level:
-```json
-{
-	"eslintConfig": {
-		"extends": "smartcar",
-		"rules": {
-			"camelcase": "off"
-		}
-	}
-}
+```js
+module.exports = {
+  extends: 'smartcar/browser',
+  rules: {
+    camelcase: 'off',
+  },
+};
 ```
 
 - Ignoring files or folders: Create a `.eslintignore` file at the root of your project

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var test = require('ava');
-var eslint = require('eslint');
-var tempWrite = require('temp-write');
-var isPlainObj = require('is-plain-obj');
+const test = require('ava');
+const eslint = require('eslint');
+const tempWrite = require('temp-write');
+const isPlainObj = require('is-plain-obj');
 
 function runEslint(str, conf) {
-  var linter = new eslint.CLIEngine({
+  const linter = new eslint.CLIEngine({
     useEslintrc: false,
     configFile: tempWrite.sync(JSON.stringify(conf))
   });
@@ -15,21 +15,21 @@ function runEslint(str, conf) {
 }
 
 test('main', function(t) {
-  var conf = require('../');
+  const conf = require('../');
 
   t.true(isPlainObj(conf));
   t.true(isPlainObj(conf.rules));
 
-  var errors = runEslint('\'use strict\';\nconsole.log("unicorn")\n', conf);
+  const errors = runEslint('\'use strict\';\nconsole.log("unicorn")\n', conf);
   t.is(errors[0].ruleId, 'no-console');
 });
 
 test('browser', function(t) {
-  var conf = require('../browser');
+  const conf = require('../browser');
 
   t.true(isPlainObj(conf));
 
-  var errors = runEslint('\'use strict\';\nprocess.exit();\n', conf);
+  const errors = runEslint('\'use strict\';\nprocess.exit();\n', conf);
   t.is(errors[0].ruleId, 'strict');
   t.is(errors[1].ruleId, 'no-process-exit');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -30,5 +30,6 @@ test('browser', function(t) {
   t.true(isPlainObj(conf));
 
   var errors = runEslint('\'use strict\';\nprocess.exit();\n', conf);
-  t.is(errors[0].ruleId, 'no-process-exit');
+  t.is(errors[0].ruleId, 'strict');
+  t.is(errors[1].ruleId, 'no-process-exit');
 });


### PR DESCRIPTION
- remove `eslint-plugin-script-tags`, this concern is taken care of by smartcar/miyagi
- add note about `miyagi` in readme
- use `const` for test files
- add usage disclaimer
- update readme to suggest `.eslintrc.js` instead for `package.json` for config