### PR TITLE
Expanded regex for max-len to ignore lines that are comment blocks wi…

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ module.exports = {
       comments: 100,
       ignoreUrls: true,
       ignoreRegExpLiterals: true,
-      ignorePattern: '^\\s*(.+=\\s*(require|rewire)|test)\\s*\\(',
+      ignorePattern: '^\\s*((.+=\\s*(require|rewire)\\s*\\()|(\\*\\s*@[^\\s]*\\s*))'
     }],
     'max-lines': 'off',
     'max-nested-callbacks': ['error', 5],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-smartcar",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Shareable eslint config for smartcar",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This would make the `max-len` rule slightly more permissive, allowing comment blocks to exceed the length limit when the given line is a JSDoc tag (see `@param` lines below):

```javascript
/**
 *
 * @param {string} someParameter more important that docblock tags stay one line as multiple lines are harder to read and parse by tools
 * @param {string} objectLiteral.propA.subPropB.subSubPropC.subSubSubPropD some deeply nested object literal property that should be documented
 **/
``` 

