### PR TITLE
Allow arrow explicit return conditional

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ module.exports = {
     'constructor-super': 'error',
     'generator-star-spacing': ['error', {before: false, after: true}],
     'no-class-assign': 'error',
-    'no-confusing-arrow': 'error',
+    'no-confusing-arrow': ['error', {allowParens: true}],
     'no-const-assign': 'error',
     'no-dupe-class-members': 'error',
     'no-duplicate-imports': 'off', //  imports are not used


### PR DESCRIPTION
Wanted to do the following
```
const someFn = (name) => name === 'special' ? doSpecialCasing(name) : doStandardCasing(name);
```

And the linter yelled at me. I don't think the above is confusing, but maybe this `allowParens: true` will get us halfway there.