### PR TITLE
chore: Upgrade eslint-plugin-mocha to 10.5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -591,7 +591,7 @@ module.exports = {
     'node/no-unsupported-features/es-syntax': 'error',
     'node/no-unsupported-features/node-builtins': 'error',
     'node/process-exit-as-throw': 'error',
-    // TODO [2022-05-31]: enable once the following issue is resolved:
+    // TODO [2025-05-31]: enable once the following issue is resolved:
     // https://github.com/mysticatea/eslint-plugin-node/issues/96
     'node/shebang': 'off',
 
@@ -704,7 +704,7 @@ module.exports = {
     'unicorn/no-abusive-eslint-disable': 'error',
     'unicorn/no-array-instanceof': 'error',
     'unicorn/no-console-spaces': 'error',
-    // TODO [2022-05-31]: enable once the following issue is resolved:
+    // TODO [2025-05-31]: enable once the following issue is resolved:
     // https://github.com/sindresorhus/eslint-plugin-unicorn/issues/787
     'unicorn/no-fn-reference-in-iterator': 'off',
     'unicorn/no-for-loop': 'error',

--- a/mocha.js
+++ b/mocha.js
@@ -36,5 +36,7 @@ module.exports = {
     'mocha/valid-suite-description': 'off',
     'mocha/valid-test-description': 'off',
     'mocha/no-async-describe': 'error',
+    'mocha/no-empty-description': 'error',
+    'mocha/consistent-spacing-between-blocks': 'error',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-plugin-import": "2.22.1",
         "eslint-plugin-jsdoc": "30.7.8",
         "eslint-plugin-lodash": "7.1.0",
-        "eslint-plugin-mocha": "8.0.0",
+        "eslint-plugin-mocha": "^10.5.0",
         "eslint-plugin-no-use-extend-native": "0.5.0",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "3.1.4",
@@ -2795,18 +2795,36 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
-      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
+      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
       "dependencies": {
-        "eslint-utils": "^2.1.0",
-        "ramda": "^0.27.1"
+        "eslint-utils": "^3.0.0",
+        "globals": "^13.24.0",
+        "rambda": "^7.4.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-plugin-no-use-extend-native": {
@@ -3618,9 +3636,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -8951,10 +8969,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+    "node_modules/rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA=="
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -12882,12 +12900,23 @@
       "requires": {}
     },
     "eslint-plugin-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
-      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
+      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
       "requires": {
-        "eslint-utils": "^2.1.0",
-        "ramda": "^0.27.1"
+        "eslint-utils": "^3.0.0",
+        "globals": "^13.24.0",
+        "rambda": "^7.4.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-no-use-extend-native": {
@@ -13487,9 +13516,9 @@
       }
     },
     "globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -17302,10 +17331,10 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
-    "ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+    "rambda": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
+      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA=="
     },
     "rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsdoc": "30.7.8",
     "eslint-plugin-lodash": "7.1.0",
-    "eslint-plugin-mocha": "8.0.0",
+    "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-no-use-extend-native": "0.5.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.4",


### PR DESCRIPTION
eslint-plugin-mocha 8.0.0, the version we are using, has a big performance regression (https://github.com/lo1tuma/eslint-plugin-mocha/issues/268) that was fixed in 8.2.0. This is adding a lot to the lint times in our projects that use mocha.

By enabling eslint's performance debugger, we can see that the rules from eslint-plugin-mocha are taking **over half (55.8%)** of the total linting time in API:
```
Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
prettier/prettier                             | 70650.452 |    26.5%
mocha/no-nested-tests                         | 24140.981 |     9.1%
mocha/no-identical-title                      | 21887.895 |     8.2%
mocha/no-skipped-tests                        | 15351.789 |     5.8%
mocha/no-exclusive-tests                      | 15245.471 |     5.7%
mocha/no-exports                              | 10354.981 |     3.9%
mocha/no-mocha-arrows                         | 10110.429 |     3.8%
mocha/max-top-level-suites                    |  8884.996 |     3.3%
mocha/no-global-tests                         |  8150.112 |     3.1%
mocha/no-sibling-hooks                        |  8075.012 |     3.0%
mocha/no-top-level-hooks                      |  8042.759 |     3.0%
mocha/no-pending-tests                        |  8001.583 |     3.0%
mocha/no-async-describe                       |  7954.872 |     3.0%
...
```

After updating eslint-plugin-mocha, the mocha rules no longer appear in the top 15 slowest rules, and the proportion of the linting time taken by eslint-plugin-mocha is down to **under 2%**. The total linting time for API is down from **5 min 12 sec to 3 min 7 sec**.

```
Rule                                          | Time (ms) | Relative
:---------------------------------------------|----------:|--------:
prettier/prettier                             | 81855.744 |    60.5%
jsdoc/check-access                            |  2384.674 |     1.8%
jsdoc/valid-types                             |  1829.143 |     1.4%
jsdoc/check-types                             |  1741.743 |     1.3%
jsdoc/check-alignment                         |  1591.156 |     1.2%
jsdoc/check-property-names                    |  1561.683 |     1.2%
jsdoc/check-tag-names                         |  1512.126 |     1.1%
jsdoc/check-syntax                            |  1509.396 |     1.1%
jsdoc/newline-after-description               |  1503.218 |     1.1%
jsdoc/require-hyphen-before-param-description |  1503.137 |     1.1%
jsdoc/empty-tags                              |  1495.594 |     1.1%
jsdoc/require-property-name                   |  1468.107 |     1.1%
jsdoc/require-property-type                   |  1454.992 |     1.1%
jsdoc/require-property                        |  1444.877 |     1.1%
import/no-self-import                         |  1302.377 |     1.0%
...
```